### PR TITLE
Ensure Gtoone_step2 returns orthonormal rotation

### DIFF
--- a/src/BaseMotions.jl
+++ b/src/BaseMotions.jl
@@ -81,10 +81,14 @@ function Gtoone_step2(zg)
     #      sin(θ)  cos(θ) 0;
     #      0       0      1]
     d = complex_normal_form(_norm(x, y))
+    if _approx_zero(d)
+        return I(x)
+    end
     M = [x y 0;
          -y x 0;
-         0 0 0]
-    rot = inv(d).*M
-    M[3, 3] = 1
+         0 0 d]
+    rot = inv(d) .* M
+    # Ensure numerical stability by projecting back into the reals when applicable.
+    rot = _set(rot)
     return rot
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,15 @@ np(S) = S.center + [0, 0, 1]
 
         tr = MobiusSphere.Gtoone_step1(B_south, B_south)
         @test tr ≈ zeros(3) atol=NUM_TOL
+
+        @testset "Gtoone_step2 Rotation" begin
+            rot = MobiusSphere.Gtoone_step2(complex(0.6, -0.8))
+            P = [0.3, -0.4, 0.5]
+            rotated = rot * P
+            rot_I = Matrix{eltype(rot)}(I, 3, 3)
+            @test rot' * rot ≈ rot_I atol=NUM_TOL
+            @test abs(rotated[3]) ≈ abs(P[3]) atol=NUM_TOL
+        end
     end
 
     @testset "Mobius to Rigid Transformation" begin


### PR DESCRIPTION
## Summary
- ensure `Gtoone_step2` constructs a full 3×3 matrix before normalization
- normalize the rotation to keep the z-axis invariant and return the identity when the input is degenerate
- add a regression test confirming the rotation is orthonormal and preserves the z-component magnitude

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: `command not found: julia`)*

------
https://chatgpt.com/codex/tasks/task_e_68df7466c18c8327ba1b800f6f9779f2