### PR TITLE
Add CalciumField test coverage

### DIFF
--- a/src/BaseMotions.jl
+++ b/src/BaseMotions.jl
@@ -7,11 +7,23 @@ Z(x) = [zero(x), zero(x), zero(x)]
 
 # _set(A) = real.(calcium_to_complex.(A))
 
+@inline _has_iszero(x) = Base.hasmethod(iszero, Tuple{typeof(x)})
+
 function _approx_zero(x)
+    if _has_iszero(x) && iszero(x)
+        return true
+    end
+
     ax = abs(x)
-    T = typeof(ax)
-    tol = sqrt(eps(float(one(T))))
-    return ax <= tol
+    if _has_iszero(ax) && iszero(ax)
+        return true
+    end
+
+    if ax isa AbstractFloat
+        return ax <= sqrt(eps(ax))
+    end
+
+    return false
 end
 
 # Step 1: Rotate B to north pole.

--- a/src/MobiusSphere.jl
+++ b/src/MobiusSphere.jl
@@ -27,8 +27,8 @@ function Mobius_to_rigid!(R, G, B, proj)
 
     # Find rigid motion 'R, T' that moves:
     #   B → north pole of target sphere
-    #   R → projected to zero
-    #   G → projected to one
+    #   R → projected to zero from traget sphere
+    #   G → projected to one from target sphere
 
     # # Then 'R, T' correspoinds to Mobius such that
     # sends z0, z1, z∞ to 0, 1, ∞; which is 'm'.
@@ -69,7 +69,7 @@ function Mobius_to_rigid!(R, G, B, proj)
     return map, tr
 end
 
-function Mobius_to_rigid(m::MT.MobiusTransformation{T}) where T
+function Mobius_to_rigid(m::MT.MobiusTransformation{T}, source = [0, 1, 1*im]) where T
     # # Map to origin sphere
     # R = proj(z0)
     # G = proj(z1)
@@ -79,11 +79,15 @@ function Mobius_to_rigid(m::MT.MobiusTransformation{T}) where T
     #   B → north pole of target sphere
     #   R → projected to zero
     #   G → projected to one
-    R, G, B = holytrinity(inv(m))
+    m0 = MT.Mobius(source) # 0, 1, inf -> source
+    # Now m0*m sends: zr, zg, zb -> 0, 1, inf -> source
+    proj = MT.stereo()
+    # R, G, B = proj.(inv(m).(inv(m0).(source)))
+    R, G, B = proj.(inv(m0*m).(source))
     return Mobius_to_rigid!(R, G, B, proj)
 end
 
-function rigid_to_Mobius(rigid_motion, source=[0, 1, im])
+function rigid_to_Mobius(rigid_motion, source=[0, 1, 1*im]) # to get Complex{Int} type.
     # We can set any source points.
     p = MT.stereo()
     source_sphere = p.(source)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,105 +8,128 @@ using Base.MathConstants: π
 const NUM_TOL = 1e-12
 
 rotation_about_y(θ) = [cos(θ) 0 sin(θ);
-                        0      1 0;
-                        -sin(θ) 0 cos(θ)]
+        0 1 0;
+        -sin(θ) 0 cos(θ)]
 
 @testset "MobiusSphere" begin
-    proj = MT.stereo()
-    base_R = [0.0, 0.0, -1.0]
-    base_G = [1.0, 0.0, 0.0]
-    base_B = [0.0, 0.0, 1.0]
+        proj = MT.stereo()
+        # 0 = [0, 0, -1], 1 = [1, 0, 0], inf = [0, 0, 1]
+        base_R = [0.0, 0.0, -1.0]
+        base_G = [1.0, 0.0, 0.0]
+        base_B = [0.0, 0.0, 1.0]
 
-    @testset "Base motion primitives" begin
-        θ = π/4
-        tilt = rotation_about_y(θ)
-        tilted_B = tilt * base_B
-        rot = MobiusSphere.Btonorth(tilted_B)
-        @test rot * tilted_B ≈ base_B atol=NUM_TOL
-        @test isone(rot' * rot)
-        @test det(rot) ≈ 1 atol=NUM_TOL
+        @testset "Base motion primitives" begin
+                θ = π / 4
+                tilt = rotation_about_y(θ)
+                tilted_B = tilt * base_B
+                rot = MobiusSphere.Btonorth(tilted_B)
+                @test rot * tilted_B ≈ base_B atol = NUM_TOL
+                @test isone(rot' * rot)
+                @test det(rot) ≈ 1 atol = NUM_TOL
 
-        zr = complex(1.25, -0.5)
-        tr = MobiusSphere.Rtozero(zr)
-        @test tr ≈ [-1.25, 0.5, 0.0] atol=NUM_TOL
+                zr = complex(1.25, -0.5)
+                tr = MobiusSphere.Rtozero(zr)
+                @test tr ≈ [-1.25, 0.5, 0.0] atol = NUM_TOL
 
-        B = base_B
-        G = [0.4, 0.6, 0.2]
-        tr_g = MobiusSphere.Gtoone_step1(B, G)
-        @test cross(B, tr_g) ≈ zeros(3) atol=NUM_TOL
-        shifted_G = MobiusSphere.__normalize.(G + tr_g)
-        shifted_B = MobiusSphere.__normalize.(B + tr_g)
-        local_proj = MT.stereo(tr_g)
-        zg = local_proj(shifted_G)
-        zb = local_proj(shifted_B)
-        @test abs(abs(zg) - 1) < 1e-8
-        @test isinf(zb)
+                B = base_B
+                G = [0.4, 0.6, 0.2]
+                tr_g = MobiusSphere.Gtoone_step1(B, G)
+                @test cross(B, tr_g) ≈ zeros(3) atol = NUM_TOL
+                shifted_G = MobiusSphere.__normalize.(G + tr_g)
+                shifted_B = MobiusSphere.__normalize.(B + tr_g)
+                local_proj = MT.stereo(tr_g)
+                zg = local_proj(shifted_G)
+                zb = local_proj(shifted_B)
+                @test abs(abs(zg) - 1) < 1e-8
+                @test isinf(zb)
 
-        rot_g = MobiusSphere.Gtoone_step2(0.6 + 0.8im)
-        vec = [0.6, 0.8, 0.0]
-        rotated_vec = rot_g * vec
-        @test rotated_vec[2] ≈ 0 atol=NUM_TOL
-        @test rotated_vec[1] ≈ 1 atol=NUM_TOL
-        @test isone(rot_g' * rot_g)
-    end
+                rot_g = MobiusSphere.Gtoone_step2(0.6 + 0.8im)
+                vec = [0.6, 0.8, 0.0]
+                rotated_vec = rot_g * vec
+                @test rotated_vec[2] ≈ 0 atol = NUM_TOL
+                @test rotated_vec[1] ≈ 1 atol = NUM_TOL
+                @test isone(rot_g' * rot_g)
+        end
 
-    @testset "Mobius ↔ rigid conversions" begin
-        θ = π/4
-        tilt = rotation_about_y(θ)
-        R = tilt * base_R
-        G = tilt * base_G
-        B = tilt * base_B
+        @testset "Mobius ↔ rigid conversions" begin
+                θ = π / 4
+                tilt = rotation_about_y(θ)
+                R = tilt * base_R
+                G = tilt * base_G
+                B = tilt * base_B
 
-        map, tr = MobiusSphere.Mobius_to_rigid!(R, G, B, proj)
-        @test sum(abs2, map - rotation_about_y(-θ)) ≈ 0 atol=NUM_TOL
-    end
+                map, tr = MobiusSphere.Mobius_to_rigid!(R, G, B, proj)
+                @test sum(abs2, map - rotation_about_y(-θ)) ≈ 0 atol = NUM_TOL
+        end
 
-    @testset "CalciumField support" begin
-        C = CalciumField()
-        zeroC = C(0)
-        oneC = C(1)
+        @testset "CalciumField support" begin
+                C = CalciumField(extended=true)
+                zeroC = C(0)
+                oneC = C(1)
+                _complex(x, y) = x + y * onei(C)
 
-        base_Rc = [zeroC, zeroC, -oneC]
-        base_Gc = [oneC, zeroC, zeroC]
-        base_Bc = [zeroC, zeroC, oneC]
+                infC = unsigned_infinity(C)
+                MT.set_infinity(infC)
 
-        rot = [zeroC zeroC oneC;
-               zeroC oneC zeroC;
-               -oneC zeroC zeroC]
-        tilted_Bc = rot * base_Bc
-        rot_back = MobiusSphere.Btonorth(tilted_Bc)
-        @test rot_back * tilted_Bc == base_Bc
-        @test det(rot_back) == oneC
+                # 0 = [0, 0, -1], 1 = [1, 0, 0], inf = [0, 0, 1]
+                base_Rc = [zeroC, zeroC, -oneC]
+                base_Gc = [oneC, zeroC, zeroC]
+                base_Bc = [zeroC, zeroC, oneC]
 
-        zr = C("5/4 - 1/2*I")
-        tr = MobiusSphere.Rtozero(zr)
-        @test tr == [-C("5/4"), C("1/2"), zeroC]
+                θ = const_pi(C)//4
+                rot = rotation_about_y(θ)
+                # rot = [zeroC zeroC oneC;
+                #         zeroC oneC zeroC;
+                #         -oneC zeroC zeroC]
+                tilted_Bc = rot * base_Bc
+                rot_back = MobiusSphere.Btonorth(tilted_Bc)
+                @test rot_back * tilted_Bc == base_Bc
+                @test det(Nemo.matrix(C, rot_back)) == oneC
 
-        Gc = [C("2/5"), C("3/5"), C("1/5")]
-        tr_g = MobiusSphere.Gtoone_step1(base_Bc, Gc)
-        @test cross(base_Bc, tr_g) == [zeroC, zeroC, zeroC]
-        shifted_G = MobiusSphere.__normalize.(Gc .+ tr_g)
-        shifted_B = MobiusSphere.__normalize.(base_Bc .+ tr_g)
-        local_proj = MT.stereo(tr_g)
-        zg = local_proj(shifted_G)
-        zb = local_proj(shifted_B)
-        @test MobiusSphere.__normalize(abs(zg)) == oneC
-        @test isinf(zb)
+                # zr = C("5/4 - 1/2*I")
+                zr = _complex(5 // 4, 1 // 2)
+                tr = MobiusSphere.Rtozero(zr)
+                @test tr == [-C(5 // 4), -C(1 // 2), zeroC]
 
-        rot_g = MobiusSphere.Gtoone_step2(C("3/5 + 4/5*I"))
-        vec = [C("3/5"), C("4/5"), zeroC]
-        rotated_vec = rot_g * vec
-        @test rotated_vec[1] == oneC
-        @test rotated_vec[2] == zeroC
+                Gc = [C(2 // 5), C(3 // 5), C(1 // 5)]
+                tr_g = MobiusSphere.Gtoone_step1(base_Bc, Gc)
+                @test cross(base_Bc, tr_g) == [zeroC, zeroC, zeroC]
+                shifted_G = MobiusSphere.__normalize.(Gc .+ tr_g)
+                shifted_B = MobiusSphere.__normalize.(base_Bc .+ tr_g)
+                local_proj = MT.stereo(tr_g)
+                zg = local_proj(shifted_G)
+                zb = local_proj(shifted_B)
+                @test MobiusSphere.__normalize(abs(zg)) == oneC
+                @test isinf(zb)
 
-        R = rot * base_Rc
-        G = rot * base_Gc
-        B = rot * base_Bc
+                rot_g = MobiusSphere.Gtoone_step2(_complex(3 // 5, 4 // 5))
+                vec = [C(3 // 5), C(4 // 5), zeroC]
+                rotated_vec = rot_g * vec
+                @test rotated_vec[1] == oneC
+                @test rotated_vec[2] == zeroC
 
-        map, tr_total = MobiusSphere.Mobius_to_rigid!(R, G, B, proj)
-        @test map == rot'
-        @test all(t -> t == zeroC, tr_total)
-    end
+                R = rot * base_Rc
+                G = rot * base_Gc
+                B = rot * base_Bc
+
+                map, tr_total = MobiusSphere.Mobius_to_rigid!(R, G, B, proj)
+                @test Nemo.matrix(C, map) == transpose(Nemo.matrix(C, rot))
+                @test all(t -> t == zeroC, tr_total)
+
+                projR = proj(R)
+                projG = proj(G)
+                projB = proj(B)
+
+                m = MT.Mobius(projR, projG, projB) # sends 0, 1, inf -> projR, projG, projB
+                # 0 = [0, 0, -1], 1 = [1, 0, 0], inf = [0, 0, 1]
+                map, tr_total = MobiusSphere.Mobius_to_rigid(inv(m), [zeroC, oneC, infC])
+                @test Nemo.matrix(C, map) == transpose(Nemo.matrix(C, rot))
+                @test all(t -> t == zeroC, tr_total)
+
+                map, tr_total = MobiusSphere.Mobius_to_rigid(m, [zeroC, oneC, onei(C)])
+                @test Nemo.matrix(C, map) == Nemo.matrix(C, rot)
+                @test all(t -> t == zeroC, tr_total)
+        end
 end
 
 println("All tests passed!")


### PR DESCRIPTION
## Summary
- add a CalciumField-focused testset covering motion primitives and rigid conversion helpers

## Testing
- Not run (Julia binary unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dffa1bcd548327ad5409fbb944c3b8