### PR TITLE
Add axis-angle extraction for rotation matrices

### DIFF
--- a/src/MobiusSphere.jl
+++ b/src/MobiusSphere.jl
@@ -7,6 +7,10 @@ export Mobius_to_rigid!
 
 using Nemo, NemoUtils
 
+@inline _cross(u, v) = [u[2] * v[3] - u[3] * v[2],
+                       u[3] * v[1] - u[1] * v[3],
+                       u[1] * v[2] - u[2] * v[1]]
+
 @inline __normalize(z::Number) = z
 @inline __normalize(z) = Nemo.complex_normal_form(z)
 
@@ -115,6 +119,48 @@ That is, the map `m` is defined as `m(z) = p_T(Q*p(z)+T)`, where `p = stereo()` 
 """
 rigid_to_Mobius(Rot::AbstractMatrix, Trans::AbstractVecOrMat, source = [0, 1, 1*im]) =
     rigid_to_Mobius(pt -> Rot*pt + Trans, source)
+
+function rotation_axis_angle(R::AbstractMatrix)
+    size(R) == (3, 3) || throw(DimensionMismatch("rotation matrices must be 3×3"))
+    x = R[1, 1]
+    Id = I(x)
+    tr = R[1, 1] + R[2, 2] + R[3, 3]
+    one_x = one(x)
+    cosθ = __normalize((tr - one_x) / 2)
+    if cosθ isa AbstractFloat
+        cosθ = clamp(cosθ, -one_x, one_x)
+    end
+    θ = acos(cosθ)
+    if _approx_zero(θ)
+        axis = [one_x, zero(x), zero(x)]
+        return axis, zero(θ)
+    end
+    sinθ = sin(θ)
+    axis_skew = [R[3, 2] - R[2, 3], R[1, 3] - R[3, 1], R[2, 1] - R[1, 2]]
+    axis = nothing
+    if !_approx_zero(axis_skew[1]^2 + axis_skew[2]^2 + axis_skew[3]^2)
+        if _approx_zero(sinθ)
+            norm_axis = sqrt(__normalize(axis_skew[1]^2 + axis_skew[2]^2 + axis_skew[3]^2))
+            axis = axis_skew ./ norm_axis
+        else
+            axis = axis_skew ./ (2 * sinθ)
+        end
+    else
+        rows = [R[i, :] .- Id[i, :] for i in 1:3]
+        for (i, j) in ((1, 2), (1, 3), (2, 3))
+            candidate = _cross(rows[i], rows[j])
+            if !_approx_zero(candidate[1]^2 + candidate[2]^2 + candidate[3]^2)
+                norm_axis = sqrt(__normalize(candidate[1]^2 + candidate[2]^2 + candidate[3]^2))
+                axis = candidate ./ norm_axis
+                break
+            end
+        end
+    end
+    if axis === nothing
+        axis = [one_x, zero(x), zero(x)]
+    end
+    return __normalize.(axis), θ
+end
 
 # Helper function: rotation matrix from axis-angle
 # function rotation_matrix(axis::AbstractVector, θ::Real)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,6 +62,30 @@ rotation_about_y(θ) = [cos(θ) 0 sin(θ);
                 @test sum(abs2, map - rotation_about_y(-θ)) ≈ 0 atol = NUM_TOL
         end
 
+        @testset "Rotation axis-angle" begin
+                θ = π / 3
+                rot = rotation_about_y(θ)
+                axis, angle = MobiusSphere.rotation_axis_angle(rot)
+                @test axis ≈ [0.0, 1.0, 0.0] atol = NUM_TOL
+                @test angle ≈ θ atol = NUM_TOL
+
+                I3 = Matrix{Float64}(I, 3, 3)
+                axis_id, angle_id = MobiusSphere.rotation_axis_angle(I3)
+                @test axis_id ≈ [1.0, 0.0, 0.0] atol = NUM_TOL
+                @test angle_id ≈ 0.0 atol = NUM_TOL
+
+                raw_axis = [1.0, 1.0, 1.0]
+                norm_axis = raw_axis / norm(raw_axis)
+                rot_pi = let x = norm_axis[1], y = norm_axis[2], z = norm_axis[3], c = cos(π), s = sin(π), v = 1 - c
+                        [c + x^2 * v    x * y * v - z * s  x * z * v + y * s;
+                         y * x * v + z * s  c + y^2 * v    y * z * v - x * s;
+                         z * x * v - y * s  z * y * v + x * s  c + z^2 * v]
+                end
+                axis_pi, angle_pi = MobiusSphere.rotation_axis_angle(rot_pi)
+                @test isapprox(angle_pi, π; atol = NUM_TOL)
+                @test isapprox(axis_pi, norm_axis; atol = NUM_TOL) || isapprox(axis_pi, -norm_axis; atol = NUM_TOL)
+        end
+
         @testset "CalciumField support" begin
                 C = CalciumField(extended=true)
                 zeroC = C(0)


### PR DESCRIPTION
## Summary
- add a helper that recovers the rotation axis and angle from a 3×3 rotation matrix
- cover the new functionality with unit tests, including edge cases

## Testing
- julia --project -e 'using Pkg; Pkg.test()' *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e02faa5ccc832791d47efa4cde24b8