### PR TITLE
PR-1: math cleanup — Nemo→weakdep, fix broken code, remove UnPack

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,18 @@ version = "1.0.0-DEV"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[weakdeps]
 Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
-NemoUtils = "36cc3343-9759-42d5-9715-21f2490c7e35"
+
+[extensions]
+MobiusSphereNemoExt = "Nemo"
 
 [compat]
 
 [extras]
+Nemo = "2edaba10-b0f1-5616-af89-8c11ac63239a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Nemo"]

--- a/ext/MobiusSphereNemoExt.jl
+++ b/ext/MobiusSphereNemoExt.jl
@@ -1,0 +1,9 @@
+module MobiusSphereNemoExt
+
+using MobiusSphere
+import Nemo: CalciumFieldElem, complex_normal_form
+
+# Simplify Nemo CalciumField expressions; triggered when Nemo is loaded.
+MobiusSphere.__normalize(z::CalciumFieldElem) = complex_normal_form(z)
+
+end

--- a/src/MobiusSphere.jl
+++ b/src/MobiusSphere.jl
@@ -1,129 +1,77 @@
-# ================ MobiusSphere.jl ================
 module MobiusSphere
 
-export Mobius_to_rigid!
-
-# using UnPack: @unpack
-# using Nemo, NemoUtils
-
-@inline _cross(u, v) = [u[2] * v[3] - u[3] * v[2],
-                       u[3] * v[1] - u[1] * v[3],
-                       u[1] * v[2] - u[2] * v[1]]
-
-@inline __normalize(z::Number) = z
-@inline __normalize(z) = Nemo.complex_normal_form(z)
-
-# import MobiusTransformations as MT
-
-# For rigid transformations in 3D
-# import CoordinateTransformations as CT
-# import Rotations as RR
+export Mobius_to_rigid!, Mobius_to_rigid, rigid_to_Mobius, rotation_axis_angle
 
 include("BaseMotions.jl")
 include("MobiusTransformations.jl")
-include("StereographicProjections.jl")
 
-# Decompose Möbius transformation 'm' to rigid transformation 'R, T'.
+import .MobiusTransformations as MT
+using .MobiusTransformations: MobiusTransformation, Möbius, Mobius, stereo
+export MobiusTransformation, Möbius, Mobius, stereo
+
+@inline _cross(u, v) = [u[2] * v[3] - u[3] * v[2],
+                        u[3] * v[1] - u[1] * v[3],
+                        u[1] * v[2] - u[2] * v[1]]
+
+# Default: identity for plain Number types.
+# MobiusSphereNemoExt adds a method for Nemo types when Nemo is loaded.
+@inline __normalize(z::Number) = z
+@inline __normalize(v::AbstractArray) = __normalize.(v)
+
+# Decompose Möbius transformation into rigid motion (R, T).
+# R, G, B are pre-images of 0, 1, ∞ on the unit sphere (output of stereo.(inv(m).(source))).
 function Mobius_to_rigid!(R, G, B, proj)
-    # # Map to origin sphere
-    # R = proj(z0) # z0 = inv(m)(0)
-    # G = proj(z1) # z1 = inv(m)(1)
-    # B = proj(z∞) # z∞ = inv(m)(∞)
-
-    # Find rigid motion 'R, T' that moves:
-    #   B → north pole of target sphere
-    #   R → projected to zero from traget sphere
-    #   G → projected to one from target sphere
-
-    # # Then 'R, T' correspoinds to Mobius such that
-    # sends z0, z1, z∞ to 0, 1, ∞; which is 'm'.
-
-    # Step 1: Rotate B to north pole.
-    # axis_rot1 = [-B[2],B[1],0] # = cross(B_rot, SVector(0, 0, 1))
-    # angle_rot1 = acos(B[3]) # = angle(B_rot, SVector(0, 0, 1))
     points = [R, G, B]
-    # print("B to north\n")
+
     rot1 = Btonorth(points[3])
     points = [rot1*p for p in points]
-    # R, G, B = [rot1].*[R, G, B]
-    # all(points[3] .== [0, 0, 1]) |> println
 
-  (if-let ((project (project-current)))
-       (expand-file-name (project-root project))
-       (message "hola")
-       (expand-file-name default-directory))
-
-    # print("R to zero\n")
     zr = proj(points[1])
     tr1 = Rtozero(zr)
     points = [p+tr1 for p in points]
-    # R, G, B = [tr1].+[R, G, B]
 
-    # print("G to one (step 1)\n")
     tr2 = Gtoone_step1(points[3], points[2])
     points = [__normalize.(p+tr2) for p in points]
-    # R, G, B = [tr2].+[R, G, B]
     temp_proj = MT.stereo(tr1+tr2)
     zg = temp_proj(points[2])
-    # println("Norm of zg: ", _norm(reim(zg)...) == 1)
 
-    # print("G to one (step 2)\n")
     rot2 = Gtoone_step2(zg)
-    points = [rot2*p for p in points]
 
-    # map = rot2 ∘ tr2 ∘ tr1 ∘ rot1
-    # print("Final Translation\n")
     tr = rot2*(tr1 + tr2)
-    # print("Final Rotation")
     map = rot2 * rot1
     return __normalize(map), __normalize(tr)
 end
 
 """
-    Mobius_to_rigid(m, source=[0, 1, 1*im])
+    Mobius_to_rigid(m, source=(0, 1, 2))
 
-Given a Mobius transformation `m` returns `Q, T` (`Q` rotation matrix and `T` Translation vector) such that `m(z) = p_T(Q*p(z)+T)`, where `p = stereo()` is the standard stereographic projection and `p_T = stereo(T)` stereo projection centred at `T`.
+Given a Möbius transformation `m` returns `Q, T` (rotation matrix and translation vector)
+such that `m(z) = p_T(Q*p(z)+T)`, where `p = stereo()` is the standard stereographic
+projection and `p_T = stereo(T)` is the stereo projection centred at `T`.
 """
-function Mobius_to_rigid(m::MT.MobiusTransformation{T}, source = (0, 1, 2)) where T
-    # # Map to origin sphere
-    # R = proj(z0)
-    # G = proj(z1)
-    # B = proj(z∞)
-
-    # Find rigid motion that moves:
-    #   B → north pole of target sphere
-    #   R → projected to zero
-    #   G → projected to one
-    m0 = MT.Mobius(source) # 0, 1, inf -> source
-    # Now m0*m sends: zr, zg, zb -> 0, 1, inf -> source
+function Mobius_to_rigid(m::MT.MobiusTransformation{T}, source=(0, 1, 2)) where {T}
+    m0 = MT.Mobius(source)
     proj = MT.stereo()
-    # R, G, B = proj.(inv(m).(inv(m0).(source)))
     R, G, B = proj.(inv(m0*m).(source))
     return Mobius_to_rigid!(R, G, B, proj)
 end
 
-function rigid_to_Mobius(rigid_motion, source=[0, 1, 1*im]) # to get Complex{Int} type.
-    # We can set any source points.
+function rigid_to_Mobius(rigid_motion, source=[0, 1, 1*im])
     p = MT.stereo()
     source_sphere = p.(source)
-
-    # Compute target sphere points.
     target_sphere = map(rigid_motion, source_sphere)
-
-    # Come back to complex plane (now we are centred at T)
     q = MT.stereo(rigid_motion(Z(0)))
     target = q.(target_sphere)
-
     return MT.Möbius(source, target)
 end
 
 """
     rigid_to_Mobius(Q, T, source=[0, 1, 1*im])
 
-Given a 3D rotation `Q` (so, `Q*Q'=Id` and `det(Q)=1`) and a translation vector `T`, returns the Mobius transformation `m` corresponding to rotate the standard Riemann sphere by `Q` and translate it by `T`.
-That is, the map `m` is defined as `m(z) = p_T(Q*p(z)+T)`, where `p = stereo()` is the standard stereographic projection and `p_T = stereo(T)` stereo projection centred at `T`.
+Given a 3D rotation `Q` (`Q*Q'=I`, `det(Q)=1`) and a translation vector `T`, returns
+the Möbius transformation `m` defined by `m(z) = p_T(Q*p(z)+T)`.
 """
-rigid_to_Mobius(Rot::AbstractMatrix, Trans::AbstractVecOrMat, source = [0, 1, 1*im]) =
+rigid_to_Mobius(Rot::AbstractMatrix, Trans::AbstractVecOrMat, source=[0, 1, 1*im]) =
     rigid_to_Mobius(pt -> Rot*pt + Trans, source)
 
 function rotation_axis_angle(R::AbstractMatrix)
@@ -175,24 +123,5 @@ function rotation_axis_angle(R::AbstractMatrix)
     end
     return __normalize.(axis), θ
 end
-
-# Helper function: rotation matrix from axis-angle
-# function rotation_matrix(axis::AbstractVector, θ::Real)
-#     u = normalize(axis)
-#     ux, uy, uz = u
-#     c = cos(θ)
-#     s = sin(θ)
-#     R = [c+ux^2*(1-c) ux*uy*(1-c)-uz*s ux*uz*(1-c)+uy*s;
-#         uy*ux*(1-c)+uz*s c+uy^2*(1-c) uy*uz*(1-c)-ux*s;
-#         uz*ux*(1-c)-uy*s uz*uy*(1-c)+ux*s c+uz^2*(1-c)]
-#     SMatrix{3,3}(R)
-# end
-
-# # Helper function: angle between vectors
-# function Base.angle(u::AbstractVector, v::AbstractVector)
-#     dotprod = dot(u, v)
-#     norms = norm(u) * norm(v)
-#     acos(clamp(dotprod / norms, -1, 1))
-# end
 
 end # of module

--- a/src/MobiusTransformations.jl
+++ b/src/MobiusTransformations.jl
@@ -1,20 +1,11 @@
 module MobiusTransformations
 
-# import LinearAlgebra: det
-using UnPack: @unpack
-
 import Base: inv, show, hash, ==, *, ∘, isone, typeof
 
 export Mobius, Möbius, stereo
 
 include("StereographicProjections.jl")
 
-# Tolerance constants
-# const NUM_TOL = 1e-12 # for printing,...
-# const SPHERE_TOL = 1e-8 # for detect north pole
-
-
-# Infinite to completing complaxe plane.
 const INF = Ref{Any}(complex(Inf))
 
 """
@@ -28,15 +19,10 @@ end
 
 infinity() = INF[]
 
-# Möbius transformation
 """
     MobiusTransformation{T}
 
-Represents a Möbius transformation of the form:
-f(z) = (a*z + b) / (c*z + d)
-
-# Fields
-- `a::T, b::T, c::T, d::T`: Coefficients of the transformation
+Represents a Möbius transformation `f(z) = (a*z + b) / (c*z + d)`.
 """
 struct MobiusTransformation{T} <: Function
     a::T
@@ -45,28 +31,8 @@ struct MobiusTransformation{T} <: Function
     d::T
 end
 
-# Dealing with diferent types
 MobiusTransformation(a, b, c, d) = MobiusTransformation(promote(a, b, c, d)...)
-
-# From array-alike objects
-"""
-    MobiusTransformation(A)
-
-Creates a Möbius transformation from an array or tuple of coefficients [a, b, c, d].
-"""
 MobiusTransformation(A) = MobiusTransformation(A...)
-
-
-# Computing Mobius transformations
-
-# Möbius(...) calls:
-# 4 args: Build MobiusTransformation (generic)
-# 3 args: Target Number-like -> Standard transformation
-# 6 args: Transformation source Number-like -> target Number-like
-# 1 args: Target vector -> 3 args
-# 2 args: Source, Target vectors -> 6 args
-# 1 args: arg is a Type, returns Identity (default ComplexF64)
-# ## moved to MobiusSphere ## 1 args: arg is a Matrix Q, returns "rotation by Q".
 
 """
     Möbius(a, b, c, d)
@@ -75,12 +41,12 @@ Creates a Möbius transformation with coefficients a, b, c, d.
 """
 Möbius(a, b, c, d) = MobiusTransformation(a, b, c, d)
 
-const Mobius = Möbius   # for us lazy Americans
+const Mobius = Möbius
 
 """
     Möbius(x, y, z)
 
-Returns the Möbius transformation that maps `[0, 1, Inf]` to given points.
+Returns the Möbius transformation that maps `[0, 1, Inf]` to the given points.
 Values of `Inf` are permitted.
 """
 function Möbius(x, y, z)
@@ -99,93 +65,80 @@ end
 """
     Möbius(x, y, z, X, Y, Z)
 
-Returns the Möbius transformation that maps `[x, y, z]` to `[X, Y, Z]`.
-Values of `Inf` are permitted.
+Returns the Möbius transformation mapping `[x, y, z]` to `[X, Y, Z]`.
 """
 function Möbius(x, y, z, X, Y, Z)
-    m_source = Möbius(x, y, z) # (0, 1, Inf) -> (x, y, z)
-    m_image = Möbius(X, Y, Z) # (0, 1, Inf) -> (X, Y, Z)
-    # No division performed.
-    return m_image * inv(m_source) # (x, y, z) -> (X, Y, Z)
+    m_source = Möbius(x, y, z)
+    m_image  = Möbius(X, Y, Z)
+    return m_image * inv(m_source)
 end
 
 """
     Möbius(target)
 
-Returns the Möbius transformation that maps `[0, 1, Inf]` to given `target = [z1, z2, z3]`.
-Values of `Inf` are permitted.
+Returns the Möbius transformation mapping `[0, 1, Inf]` to `target = [z1, z2, z3]`.
 """
 Möbius(target) = Möbius(target...)
-
 
 """
     Möbius(source, target)
 
-Returns the Möbius transformation that maps `source` to `target`.
-Values of `Inf` are permitted.
+Returns the Möbius transformation mapping `source` to `target`.
 """
 Möbius(source, target) = Möbius(source..., target...)
 
 """
-    Möbius(::Type{T}=ComplexF64)
+    Möbius(::Type{T}=Int64)
 
 Returns the identity Möbius transformation of type `T`.
 """
-Möbius(::Type{T}=Int64) where T = Möbius(one(T), zero(T), zero(T), one(T))
+Möbius(::Type{T}=Int64) where {T} = Möbius(one(T), zero(T), zero(T), one(T))
 
 """
     isone(m::MobiusTransformation)
 
-Return `true` if `m` is the identity Mobius transformation and `false` otherwise.
+Return `true` if `m` is the identity transformation.
 """
 function isone(m::MobiusTransformation)
-    @unpack a, b, c, d = m
+    (; a, b, c, d) = m
     return iszero(b) && iszero(c) && (a == d)
 end
-==(m::MobiusTransformation, n::MobiusTransformation) = isone(m * inv(n))
 
-# TODO
-# ≈(m::MobiusTransformation, n::MobiusTransformation) = isapproxone(m*inv(n))
-#
+==(m::MobiusTransformation, n::MobiusTransformation) = isone(m * inv(n))
 
 Base.eltype(_::MobiusTransformation{T}) where {T} = T
 
 function Base.hash(m::MobiusTransformation, h::UInt64=UInt64(0))
-    z = 0.0 + 0.0 * im # kludge to make -0.0 and -0.0im into +versions
+    z = 0.0 + 0.0 * im
     a = m(0) + z
     b = m(1) + z
     c = m(Inf) + z
     return hash(a, hash(b, hash(c, h)))
 end
 
-# Vectorized operations
 Base.broadcastable(m::MobiusTransformation) = Ref(m)
 
 function det(m::MobiusTransformation)
-    @unpack a, b, c, d = m
+    (; a, b, c, d) = m
     return a * d - b * c
 end
 
 """
     normalize(m::MobiusTransformation)
 
-Returns a Mobius transformation `m2` such that `m2 == m1` and `det(m2) = 1`.
+Returns a Möbius transformation `m2` such that `m2 == m` and `det(m2) = 1`.
 """
 normalize(m::MobiusTransformation) = inv(det(m)) * m
 
 function Base.Matrix(m::MobiusTransformation)
-    @unpack a, b, c, d = m
+    (; a, b, c, d) = m
     return [a b; c d]
 end
 
-# Inverse Möbius transformation
 function Base.inv(m::MobiusTransformation)
-    @unpack a, b, c, d = m
+    (; a, b, c, d) = m
     MobiusTransformation(d, -b, -c, a)
 end
-
-# *(λ, m::MobiusTransformation) = MobiusTransformation(λ * Matrix(m))
-# *(m::MobiusTransformation, λ) = *(λ, m)
 
 """
     *(m::MobiusTransformation, n::MobiusTransformation)
@@ -193,35 +146,27 @@ end
 Compose two Möbius transformations.
 """
 function *(m::MobiusTransformation, n::MobiusTransformation)
-    @unpack a, b, c, d = n
+    (; a, b, c, d) = n
     e, f, g, h = a, b, c, d
-    @unpack a, b, c, d = m
+    (; a, b, c, d) = m
     MobiusTransformation(a * e + b * g, a * f + b * h,
                          c * e + d * g, c * f + d * h)
 end
 
-"""
-    ∘(m::MobiusTransformation, n::MobiusTransformation)
-
-Compose two Möbius transformations (same as *).
-"""
 ∘(m::MobiusTransformation, n::MobiusTransformation) = m * n
 
-# Apply Möbius transformation
 """
     (m::MobiusTransformation)(z)
 
-Apply to a complex number z the Möbius transformation
-`m(z) = (a*z + b) / (c*z + d)`, where `m = Mobius([a b; c d])`.
+Apply `m(z) = (a*z + b) / (c*z + d)`.
 """
 function (m::MobiusTransformation)(z)
-    @unpack a, b, c, d = m
+    (; a, b, c, d) = m
     if isinf(z)
         numer, denom = a, c
     else
         numer, denom = a * z + b, c * z + d
     end
-
     if abs(denom) == 0
         return INF[]
     else
@@ -229,33 +174,22 @@ function (m::MobiusTransformation)(z)
     end
 end
 
-#
-# Display
-#
-
 function show(io::IO, m::MobiusTransformation)
-    @unpack a, b, c, d = m
+    (; a, b, c, d) = m
     print(IOContext(io, :compact => true), "Möbius map z --> ($a*z + $b) / ($c*z + $d)")
 end
 
 function show(io::IO, ::MIME"text/plain", m::MobiusTransformation)
     string_linear((X, Y)) = "(" * X * ")*z + " * Y
-    @unpack a, b, c, d = m
-    # if abs(c) < NUM_TOL
-    #     A, B = [repr("text/plain", x) for x in [a*inv(d), b*inv(d)]]
-    #     numer = string_linear((A, B))
-    #     print(io, "Möbius:\n   ", numer)
-    # end
+    (; a, b, c, d) = m
     A, B, C, D = [repr("text/plain", x) for x in [a, b, c, d]]
     numer, denom = string_linear.([(A, B), (C, D)])
     newline = "\n   "
     hline = reduce(*, fill("–", maximum(length, [numer, denom])))
-
-    ## Print message
     print(io, "Möbius: ", eltype(m), newline,
         numer, newline,
         hline, newline,
         denom)
 end
 
-end # of module MobiusTransformations.
+end # of module MobiusTransformations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Test
 using LinearAlgebra
 using MobiusSphere
 using Nemo
-import MobiusTransformations as MT
+import MobiusSphere.MobiusTransformations as MT
 using Base.MathConstants: π
 
 const NUM_TOL = 1e-12
@@ -95,22 +95,17 @@ rotation_about_y(θ) = [cos(θ) 0 sin(θ);
                 infC = unsigned_infinity(C)
                 MT.set_infinity(infC)
 
-                # 0 = [0, 0, -1], 1 = [1, 0, 0], inf = [0, 0, 1]
                 base_Rc = [zeroC, zeroC, -oneC]
                 base_Gc = [oneC, zeroC, zeroC]
                 base_Bc = [zeroC, zeroC, oneC]
 
                 θ = const_pi(C) // 4
                 rot = rotation_about_y(θ)
-                # rot = [zeroC zeroC oneC;
-                #         zeroC oneC zeroC;
-                #         -oneC zeroC zeroC]
                 tilted_Bc = rot * base_Bc
                 rot_back = MobiusSphere.Btonorth(tilted_Bc)
                 @test rot_back * tilted_Bc == base_Bc
                 @test det(Nemo.matrix(C, rot_back)) == oneC
 
-                # zr = C("5/4 - 1/2*I")
                 zr = _complex(5 // 4, 1 // 2)
                 tr = MobiusSphere.Rtozero(zr)
                 @test tr == [-C(5 // 4), -C(1 // 2), zeroC]
@@ -144,8 +139,7 @@ rotation_about_y(θ) = [cos(θ) 0 sin(θ);
                 projG = proj(G)
                 projB = proj(B)
 
-                m = MT.Mobius(projR, projG, projB) # sends 0, 1, inf -> projR, projG, projB
-                # 0 = [0, 0, -1], 1 = [1, 0, 0], inf = [0, 0, 1]
+                m = MT.Mobius(projR, projG, projB)
                 map, tr_total = MobiusSphere.Mobius_to_rigid(inv(m), [zeroC, oneC, infC])
                 @test Nemo.matrix(C, map) == transpose(Nemo.matrix(C, rot))
                 @test all(t -> t == zeroC, tr_total)


### PR DESCRIPTION
## Summary

Implements the PR-1 items from the Möbius Sphere Refactor Plan: stable, Nemo-free by default, one path through `Mobius_to_rigid`.

### Changes

**`Project.toml`**
- Remove `Nemo` and `NemoUtils` from `[deps]` — `Pkg.add("MobiusSphere")` no longer pulls Nemo
- Add `Nemo` to `[weakdeps]` and wire the extension `MobiusSphereNemoExt = "Nemo"`
- Add `Nemo` to `[extras]`/`[targets]` so the CalciumField test set still runs in `Pkg.test()`

**`src/MobiusSphere.jl`** — fix three pre-existing bugs
1. Remove accidental Emacs-Lisp snippet in the middle of `Mobius_to_rigid!` that prevented the module from parsing
2. Un-comment `import .MobiusTransformations as MT` (dot = relative import of the vendored submodule); drop the duplicate `include("StereographicProjections.jl")` that shadowed the one already inside the submodule
3. Replace `@inline __normalize(z) = Nemo.complex_normal_form(z)` with an `AbstractArray` overload that broadcasts element-wise — the extension adds the Nemo scalar method; Float64 matrices/vectors now return unchanged without touching Nemo
- Re-export `MobiusTransformation`, `Möbius`, `Mobius`, `stereo` from the vendored submodule

**`src/MobiusTransformations.jl`**
- Remove `using UnPack: @unpack`; replace all `@unpack a, b, c, d = m` with native `(; a, b, c, d) = m` destructuring (Julia ≥ 1.7)
- UnPack was only available as a transitive dep through NemoUtils; removing it makes the dep tree clean

**`ext/MobiusSphereNemoExt.jl`** *(new)*
- Loaded automatically when `Nemo` is in the environment
- Adds `MobiusSphere.__normalize(z::CalciumFieldElem) = Nemo.complex_normal_form(z)`

**`test/runtests.jl`**
- `import MobiusTransformations as MT` → `import MobiusSphere.MobiusTransformations as MT` (use the vendored submodule, no external package needed)

## Done when
- `Pkg.add("MobiusSphere")` pulls no Nemo in the default environment
- All Float64 and CalciumField test sets pass

---
_Generated by [Claude Code](https://claude.ai/code/session_017A2WM37mHM6BGw13nJnxaF)_